### PR TITLE
fix back buotton issue

### DIFF
--- a/barcodescanner/src/main/java/com/google/zxing/client/android/CaptureActivity.java
+++ b/barcodescanner/src/main/java/com/google/zxing/client/android/CaptureActivity.java
@@ -370,8 +370,21 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
   }
 
   @Override
+  public void onBackPressed() {
+    if (source == IntentSource.NATIVE_APP_INTENT) {
+      setResult(RESULT_CANCELED);
+      finish();
+    }
+    if ((source == IntentSource.NONE || source == IntentSource.ZXING_LINK) && lastResult != null) {
+      restartPreviewAfterDelay(0L);
+    }
+    super.onBackPressed();
+  }
+
+  @Override
   public boolean onKeyDown(int keyCode, KeyEvent event) {
     switch (keyCode) {
+      /*
       case KeyEvent.KEYCODE_BACK:
         if (source == IntentSource.NATIVE_APP_INTENT) {
           setResult(RESULT_CANCELED);
@@ -383,6 +396,7 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
           return true;
         }
         break;
+       */
       case KeyEvent.KEYCODE_FOCUS:
       case KeyEvent.KEYCODE_CAMERA:
         // Handle these events so they don't launch the Camera app


### PR DESCRIPTION
fix back button issue

> when the user clicks the back button on the barcode scanning screen, the onKeyDown (in CaptureActivity) will react to it and the activity will be closed.
> But the next Activity will capture the onBackPressed event, therefore it will be closed as well.
> So with one back click, 2 Activity are closed.
> https://github.com/phonegap/phonegap-plugin-barcodescanner/issues/773